### PR TITLE
Added get and modify methods for list member tags.

### DIFF
--- a/src/main/java/com/mailchimp/MailChimpClient.java
+++ b/src/main/java/com/mailchimp/MailChimpClient.java
@@ -17,6 +17,7 @@ import com.mailchimp.domain.StatusToLower;
 import com.mailchimp.domain.SubscribeStatus;
 import com.mailchimp.domain.SubscriberList;
 import com.mailchimp.domain.SubscriberLists;
+import com.mailchimp.domain.Tags;
 import feign.Param;
 import feign.RequestLine;
 
@@ -46,6 +47,12 @@ public interface MailChimpClient {
 
     @RequestLine("DELETE /3.0/lists/{list-id}/members/{subscriber-hash}")
     void removeListMember(@Param("list-id") String listId, @Param("subscriber-hash") String subscriberHash);
+
+    @RequestLine("POST /3.0/lists/{list-id}/members/{subscriber-hash}/tags")
+    void modifyListMemberTags(@Param("list-id") String listId, @Param("subscriber-hash") String subscriberHash, Tags tags);
+
+    @RequestLine("GET /3.0/lists/{list-id}/members/{subscriber-hash}/tags")
+    Tags getListMemberTags(@Param("list-id") String listId, @Param("subscriber-hash") String subscriberHash);
 
     /**
      * Create a new list in your MailChimp account.

--- a/src/main/java/com/mailchimp/domain/Tag.java
+++ b/src/main/java/com/mailchimp/domain/Tag.java
@@ -1,14 +1,11 @@
 package com.mailchimp.domain;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 /**
  * @author kimvsparrow
  */
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class Tag {
 
     public enum TagStatus {

--- a/src/main/java/com/mailchimp/domain/Tag.java
+++ b/src/main/java/com/mailchimp/domain/Tag.java
@@ -1,0 +1,20 @@
+package com.mailchimp.domain;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+/**
+ * @author kimvsparrow
+ */
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class Tag {
+
+    public enum TagStatus {
+        active, inactive
+    }
+
+    private String name;
+    private TagStatus status;
+}

--- a/src/main/java/com/mailchimp/domain/Tags.java
+++ b/src/main/java/com/mailchimp/domain/Tags.java
@@ -1,7 +1,5 @@
 package com.mailchimp.domain;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.util.ArrayList;
@@ -11,7 +9,6 @@ import java.util.List;
  * @author kimvsparrow
  */
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class Tags {
     private List<Tag> tags = new ArrayList<>();
 }

--- a/src/main/java/com/mailchimp/domain/Tags.java
+++ b/src/main/java/com/mailchimp/domain/Tags.java
@@ -1,0 +1,17 @@
+package com.mailchimp.domain;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author kimvsparrow
+ */
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class Tags {
+    private List<Tag> tags = new ArrayList<>();
+}

--- a/src/test/java/com/mailchimp/MailChimpClientTest.java
+++ b/src/test/java/com/mailchimp/MailChimpClientTest.java
@@ -5,18 +5,7 @@
  */
 package com.mailchimp;
 
-import com.mailchimp.domain.Member;
-import com.mailchimp.domain.Members;
-import com.mailchimp.domain.Root;
-import com.mailchimp.domain.SearchMembers;
-import com.mailchimp.domain.Segment;
-import com.mailchimp.domain.SegmentCreate;
-import com.mailchimp.domain.SegmentModified;
-import com.mailchimp.domain.SegmentModify;
-import com.mailchimp.domain.Segments;
-import com.mailchimp.domain.SubscribeStatus;
-import com.mailchimp.domain.SubscriberList;
-import com.mailchimp.domain.SubscriberLists;
+import com.mailchimp.domain.*;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -1136,13 +1125,50 @@ public class MailChimpClientTest {
 
     @Test
     @InSequence(18)
+    public void addMemberTag() throws InterruptedException {
+        Thread.sleep(1000);
+        Tags testTags = new Tags();
+        Tag testTag = new Tag();
+        testTag.setName("Test Tag");
+        testTag.setStatus(Tag.TagStatus.active);
+        testTags.getTags().add(testTag);
+        String hash = Member.getSubscriberHash(email);
+
+        mailChimpClient.modifyListMemberTags(listID, hash, testTags);
+        Tags response = mailChimpClient.getListMemberTags(listID, hash);
+
+        assertNotNull(response);
+        assertEquals(1, response.getTags().size());
+        assertEquals("Test Tag", response.getTags().get(0).getName());
+    }
+
+    @Test
+    @InSequence(19)
+    public void removeMemberTag() throws InterruptedException {
+        Thread.sleep(1000);
+        Tags testTags = new Tags();
+        Tag testTag = new Tag();
+        testTag.setName("Test Tag");
+        testTag.setStatus(Tag.TagStatus.inactive);
+        testTags.getTags().add(testTag);
+        String hash = Member.getSubscriberHash(email);
+
+        mailChimpClient.modifyListMemberTags(listID, hash, testTags);
+        Tags response = mailChimpClient.getListMemberTags(listID, hash);
+
+        assertNotNull(response);
+        assertTrue(response.getTags().isEmpty());
+    }
+
+    @Test
+    @InSequence(20)
     public void removeListMember() {
         Member member = mailChimpClient.getListMember(listID, Member.getSubscriberHash(email));
         mailChimpClient.removeListMember(listID, member.getId());
     }
 
     @Test
-    @InSequence(19)
+    @InSequence(21)
     public void removeList() {
         mailChimpClient.removeList(listID);
     }


### PR DESCRIPTION
Includes backing domain classes and tests.

The `SnakeCaseStrategy` isn't necessary for the new `Tag` and `Tags` classes but it's there in case a new long property name should be added for whatever reason. I find the use of this naming strategy is cleaner than adding `@JsonProperty` for everything (or even for just the long names).

Cheers, Kim