### PR TITLE
Update MailChimpError.java

### DIFF
--- a/src/main/java/com/mailchimp/domain/MailChimpError.java
+++ b/src/main/java/com/mailchimp/domain/MailChimpError.java
@@ -13,7 +13,7 @@ import lombok.ToString;
  *
  * @author stevensnoeijen
  */
-@ToString(of = {"title", "status", "detail"})
+@ToString
 public class MailChimpError {
 
     public static class BodyError {


### PR DESCRIPTION
removed ToString of fields, so it will default toString all properties (more info for debugging)